### PR TITLE
Fix broken tailwindcss link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To build:
 
 - [Clojurescript](https://clojurescript.org/)
 - [SCI](https://github.com/babashka/sci)
-- [tailwind](tailwindcss.com/)
+- [tailwind](https://tailwindcss.com/)
 - [shadow-cljs](https://github.com/thheller/shadow-cljs)
 
 ### Inspiration


### PR DESCRIPTION
I get a 404 when clicking the link in the current version of the readme. It seems the protocol is necessary.