### PR TITLE
add: github action for deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,69 @@
+name: Build and deploy GH Pages
+
+## ref: https://github.com/marketplace/actions/setup-clojure
+## ref: https://github.com/actions/setup-node
+
+on: 
+ push:
+  branches:
+   - deploy
+
+jobs:
+  build:
+    name: Publish site
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Prepare java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@12.1
+        with:
+          cli: 1.11.1.1413
+      - name: Cache clojure dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          # List all files containing dependencies:
+          key: cljdeps-${{ hashFiles('deps.edn') }}
+          # key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+          # key: cljdeps-${{ hashFiles('project.clj') }}
+          # key: cljdeps-${{ hashFiles('build.boot') }}
+          restore-keys: cljdeps-
+      - name: setup_npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: build_and_deploy
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          GITHUB_HOSTNAME="github.com"
+          TARGET_REPOSITORY=${GITHUB_REPOSITORY}
+          remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@${GITHUB_HOSTNAME}/${TARGET_REPOSITORY}.git"
+          remote_branch="gh-pages"
+
+          npm install
+          npm run build
+          
+          echo "Pushing artifacts to ${TARGET_REPOSITORY}:$remote_branch"
+
+          cd resources/public
+
+          git init
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions-bot@users.noreply.${GITHUB_HOSTNAME}"
+          git add .
+
+          git commit -m "Deploy ${TARGET_REPOSITORY} to ${TARGET_REPOSITORY}:$remote_branch"
+          git push --force "${remote_repo}" master:"${remote_branch}"
+
+          echo "Deploy complete"


### PR DESCRIPTION
This pr contains github action to generate github pages when push deploy branch.

I'm not sure what kind of method are you using currently build & hosting static web files.

When I translating tryclojure for korean, I used github action & page to deploy site.

- here is korean version : https://lispkorea.github.io/tryclojure-kr/

If you are using service which need to pay to hosting static files it can reduce cost for that except domain name.

## ref

- https://docs.github.com/en/actions
- https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/